### PR TITLE
Added `octokitScope` to define scope of octokit instance.

### DIFF
--- a/src/interfaces/octokit-module-options.interface.ts
+++ b/src/interfaces/octokit-module-options.interface.ts
@@ -1,10 +1,11 @@
-import { ModuleMetadata, Type } from '@nestjs/common';
+import { ModuleMetadata, Scope, Type } from '@nestjs/common';
 import { Octokit } from 'octokit';
 
 export interface OctokitModuleOptions {
   isGlobal?: boolean;
   octokitOptions?: ConstructorParameters<typeof Octokit>[0];
   plugins?: Parameters<typeof Octokit['plugin']>;
+  octokitScope?: Scope;
 }
 
 export type AsyncOctokitModuleOptions = Omit<OctokitModuleOptions, 'isGlobal'>;
@@ -24,4 +25,5 @@ export interface OctokitModuleAsyncOptions
     ...args: any[]
   ) => Promise<AsyncOctokitModuleOptions> | AsyncOctokitModuleOptions;
   inject?: any[];
+  octokitScope?: Scope,
 }

--- a/src/octokit.module.ts
+++ b/src/octokit.module.ts
@@ -91,7 +91,10 @@ export class OctokitModule {
     if (options.plugins) {
       MyOctokit = MyOctokit.plugin(...options.plugins);
     }
-
-    return new MyOctokit(options.octokitOptions);
+    let instanceOptions: OctokitModuleOptions["octokitOptions"] = {...options.octokitOptions};
+    if (typeof instanceOptions?.auth === "function") {
+      instanceOptions.auth = instanceOptions.auth();
+    }
+    return new MyOctokit(instanceOptions);
   }
 }

--- a/src/octokit.module.ts
+++ b/src/octokit.module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Module, Provider } from '@nestjs/common';
+import { DynamicModule, Module, Provider, Scope } from '@nestjs/common';
 import { Octokit } from 'octokit';
 import {
   OctokitModuleAsyncOptions,
@@ -20,6 +20,7 @@ export class OctokitModule {
       providers: [
         {
           provide: OCTOKIT,
+          scope: options.octokitScope || Scope.DEFAULT,
           useValue: this.instantiateOctokit(options),
         },
       ],
@@ -33,6 +34,7 @@ export class OctokitModule {
       useFactory: (options: OctokitModuleOptions) =>
         this.instantiateOctokit(options),
       provide: OCTOKIT,
+      scope: options.octokitScope || Scope.DEFAULT,
       inject: [OCTOKIT_OPTIONS],
     };
     return {


### PR DESCRIPTION
I've added an `octokitScope` to the options, and used that in the sync and async providers to set the `scope` of the OctoKit provider. This way users can configure the `OctokitModule` to create request scoped Octokit instances, which fixes #2 .

I noticed that the `options`, including `auth` did not renew when creating new Octokit instances, so I create a copy and call `auth` if it is a function, to renew it. Perhaps this isn't the optimal solution, but I didn't understand the architecture sufficiently to come up with something better.